### PR TITLE
fix: convert custom tools to function format for ChatCC compatibility

### DIFF
--- a/codex_rosetta/converters/tool_transformer.py
+++ b/codex_rosetta/converters/tool_transformer.py
@@ -275,16 +275,19 @@ class ToolTransformer:
         }
 
     def _convert_custom_tool(self, tool: dict[str, Any]) -> dict[str, Any]:
-        """Convert a custom tool to Chat Completions format."""
+        """Convert a custom tool to Chat Completions function format.
+
+        Chat Completions API only supports ``type: "function"``. The previous
+        implementation returned ``type: "custom"`` which is not understood by
+        most upstream providers (e.g. litellm, vLLM) and causes 400 errors.
+        """
         custom = tool.get("custom", tool)
-        return {
-            "type": "custom",
-            "custom": {
-                "name": custom.get("name", ""),
-                "description": custom.get("description", ""),
-                "format": custom.get("format", {"type": "text"}),
-            },
+        func_def = {
+            "name": custom.get("name", "custom_tool"),
+            "description": custom.get("description", ""),
+            "parameters": {"type": "object", "properties": {}},
         }
+        return {"type": "function", "function": func_def}
 
     def convert_tool_choice(
         self, tool_choice: Any, context: ConversionContext


### PR DESCRIPTION
## Problem

Chat Completions API only supports `type: "function"` tool definitions.
The current `_convert_custom_tool` returns `type: "custom"` which is not
understood by most upstream providers (litellm, vLLM, etc.) and causes
400 Bad Request errors.

## Reproduce

With Codex CLI 0.136.0+ using a custom provider via CodexRosetta:
stream disconnected before completion: Client error '400 Bad Request'
'function' is a required property, expected an object - 'tools.7'

## Fix

Convert custom tools to the standard `type: "function"` format with a
minimal parameters schema, ensuring compatibility with all major
Chat Completions-compatible backends.